### PR TITLE
Distinguish modules only needed for testing from those needed for run…

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,13 +12,17 @@ my %wm = (
     AUTHOR       => [ "H.Merijn Brand <h.merijn\@xs4all.nl>",
 		      "Abe Timmerman <abeltje\@cpan.org>" ],
     VERSION_FROM => "lib/System/Info.pm",
-    PREREQ_PM	 => { "Test::More"	 => 0.88,
-		      "Test::NoWarnings" => 0,
-		      },
     macro        => { TARFLAGS => "--format=ustar -c -v -f",
 		      },
     );
 $ExtUtils::MakeMaker::VERSION > 6.30 and $wm{LICENSE} = "perl";
+my $test_requires = {
+    "Test::More"	    => 0.88,
+    "Test::NoWarnings"  => 0,
+};
+($ExtUtils::MakeMaker::VERSION >= 6.64)
+    ? $wm{TEST_REQUIRES}    = $test_requires
+    : $wm{PREREQ_PM}        = $test_requires;
 
 my $rv = WriteMakefile (%wm);
 


### PR DESCRIPTION
…time.

This came up in the course of an attempt to package this distribution for an
OpenBSD port.  See: https://marc.info/?l=openbsd-ports&m=151820476213941&w=2