### PR TITLE
Avoid pod test failures 20180430

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,11 @@ Use [issues](https://github.com/Tux/System-Info/issues)
 
 # Style
 
-I will never accept pull request that do not strictly conform to my
+I will never accept pull requests that do not strictly conform to my
 style, however you might hate it. You can read the reasoning behind
 my [preferences](http://tux.nl/style.html).
 
-I really do not care about mixed spaces and tabs in (leading) whitespace
+I really do not care about mixed spaces and tabs in (leading) whitespace.
 
 Perl::Tidy will help getting the code in shape, but as all software, it
 is not perfect. You can find my preferences for these in

--- a/xt/00_perlversion.t
+++ b/xt/00_perlversion.t
@@ -10,7 +10,7 @@ if ($@ || $] < 5.010) {
     }
 eval "use Test::MinimumVersion";
 if ($@) {
-    print "1..0 # Test::MinimumVersion required for compatability tests\n";
+    print "1..0 # Test::MinimumVersion required for compatibility tests\n";
     exit 0;
     }
 

--- a/xt/00_perlversion.t
+++ b/xt/00_perlversion.t
@@ -16,6 +16,6 @@ if ($@) {
 
 my @f = sort glob ("t/*"), glob ("xt/*"), glob ("*.pm"), glob ("*.PL");
 
-all_minimum_version_ok (5.008003, { paths => [ @f ]});
+all_minimum_version_ok (5.008003, {paths => [@f]});
 
 done_testing ();

--- a/xt/02_pod_syntax.t
+++ b/xt/02_pod_syntax.t
@@ -1,10 +1,10 @@
 #! /usr/bin/perl -w
 use strict;
-use Test::More tests =>  1;
+use Test::More tests => 1;
 
 SKIP: {
     skip 'Test::Pod not installed', 1
-        unless eval { require Test::Pod; };
+	unless eval { require Test::Pod; };
 
     all_pod_files_ok ();
-}
+    }

--- a/xt/02_pod_syntax.t
+++ b/xt/02_pod_syntax.t
@@ -1,6 +1,10 @@
 #! /usr/bin/perl -w
 use strict;
+use Test::More tests =>  1;
 
-use Test::Pod;
+SKIP: {
+    skip 'Test::Pod not installed', 1
+        unless eval { require Test::Pod; };
 
-all_pod_files_ok ();
+    all_pod_files_ok ();
+}

--- a/xt/03_pod_coverage.t
+++ b/xt/03_pod_coverage.t
@@ -1,14 +1,18 @@
 #! perl -w
 use strict;
+use Test::More tests =>  1;
 
-use Test::Pod::Coverage;
+SKIP: {
+    skip 'Test::Pod::Coverage not installed', 1
+        unless eval { require Test::Pod::Coverage; };
 
-my @options = sort {
-    length($b) <=> length($a) ||
-    $a cmp $b
-} map {chomp($_); $_} <DATA>;
+    my @options = sort {
+        length($b) <=> length($a) ||
+        $a cmp $b
+    } map {chomp($_); $_} <DATA>;
 
-all_pod_coverage_ok({trustme => \@options});
+    all_pod_coverage_ok({trustme => \@options});
+}
 
 
 __DATA__

--- a/xt/03_pod_coverage.t
+++ b/xt/03_pod_coverage.t
@@ -1,19 +1,17 @@
 #! perl -w
 use strict;
-use Test::More tests =>  1;
+use Test::More tests => 1;
 
 SKIP: {
     skip 'Test::Pod::Coverage not installed', 1
-        unless eval { require Test::Pod::Coverage; };
+	unless eval { require Test::Pod::Coverage; };
 
-    my @options = sort {
-        length($b) <=> length($a) ||
-        $a cmp $b
-    } map {chomp($_); $_} <DATA>;
+    my @options =
+	sort { length ($b) <=> length ($a) || $a cmp $b }
+	map { chomp ($_); $_ } <DATA>;
 
-    all_pod_coverage_ok({trustme => \@options});
-}
-
+    all_pod_coverage_ok ({trustme => \@options});
+    }
 
 __DATA__
 adir


### PR DESCRIPTION
When I clone a Perl distribution from github.com, the **first** thing I do is to run:
```
perl Makefile.PL
make
make test
```
I expect all tests to ```PASS```.  Associated with that expectation is my expectation that I won't be asked to run any tests which the author uses to prepare for a release.  Typically that entails running tests in ```t/``` but not tests in ```xt/``` or similar directories.

When I started to play with System-Info on FreeBSD-11.1 today, I issued the above commands but got output like this:
```
xt/00_manifest.t ...... ok   
xt/00_perlversion.t ... skipped: (no reason given)
xt/02_pod_syntax.t .... Can't locate Test/Pod.pm in @INC (you may need to install the Test::Pod module) (@INC contains: /usr/home/jkeenan/gitwork/System-Info/blib/lib /usr/home/jkeenan/gitwork/System-Info/blib/arch /usr/local/lib/perl5/site_perl/mach/5.26 /usr/local/lib/perl5/site_perl /usr/local/lib/perl5/5.26/mach /usr/local/lib/perl5/5.26 .) at xt/02_pod_syntax.t line 4.
BEGIN failed--compilation aborted at xt/02_pod_syntax.t line 4.
xt/02_pod_syntax.t .... Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 
xt/03_pod_coverage.t .. Can't locate Test/Pod/Coverage.pm in @INC (you may need to install the Test::Pod::Coverage module) (@INC contains: /usr/home/jkeenan/gitwork/System-Info/blib/lib /usr/home/jkeenan/gitwork/System-Info/blib/arch /usr/local/lib/perl5/site_perl/mach/5.26 /usr/local/lib/perl5/site_perl /usr/local/lib/perl5/5.26/mach /usr/local/lib/perl5/5.26 .) at xt/03_pod_coverage.t line 4.
BEGIN failed--compilation aborted at xt/03_pod_coverage.t line 4.
xt/03_pod_coverage.t .. Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 
xt/10_perm.t .......... skipped: (no reason given)
```
I'm not sure why you are including author tests -- which is what I take those in ```xt/``` to be -- in the ```test``` target.  Why should the casual user be forced to run those tests?  However, if the casual user must run those tests, at the very least they should exit gracefully if Test::Pod and Test::Pod::Coverage are not installed.  That's the point of the first commit in this pull request.

Thank you very much.
Jim Keenan