### PR TITLE
Add android to linux detection

### DIFF
--- a/lib/System/Info.pm
+++ b/lib/System/Info.pm
@@ -72,7 +72,7 @@ sub new {
     $^O =~ m/haiku/              and return System::Info::Haiku->new;
     $^O =~ m/hp-?ux/i            and return System::Info::HPUX->new;
     $^O =~ m/irix/i              and return System::Info::Irix->new;
-    $^O =~ m/linux/i             and return System::Info::Linux->new;
+    $^O =~ m/linux|android/i     and return System::Info::Linux->new;
     $^O =~ m/solaris|sunos|osf/i and return System::Info::Solaris->new;
     $^O =~ m/VMS/                and return System::Info::VMS->new;
     $^O =~ m/mswin32|windows/i   and return System::Info::Windows->new;


### PR DESCRIPTION
Android is sort of Linux underneath and you can install perl & CPAN packages (I use Terminux), but $^O reports `android`, which then does not let System::Info detect number of cpus etc. A simple addition like this PR gives a reasonable output on my Android (running the MIUI flavor):
```
{
          'hostname' => 'localhost',
          'osname' => 'Linux',
          'cpu_cores' => '8',
          'distro' => 'Linux 5.10.136-android12-9-00021-g821df8f5bd36-ab9585204',
          'cpu_type' => 'aarch64',
          'osvers' => '5.10.136-android12-9-00021-g821df8f5bd36-ab9585204',
          'cpu' => '',
          'os' => 'linux - 5.10.136-android12-9-00021-g821df8f5bd36-ab9585204',
          'cpu_count' => 8
        };
```
The empty CPU name is because my `/proc/cpuinfo` seems kind of sparse, with the entire entry per processor being:
```
processor	: 0
BogoMIPS	: 38.40
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint i8mm bti
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd46
CPU revision	: 3
```
There were no distro files at all on my `/etc/` to add to `t/etc/` - so apologies for that, but given how little Google has left of the underlying linux, I guess we can't do much and I thought we can just take this "easy win".