### PR TITLE
Darwin fixes

### DIFF
--- a/lib/System/Info.pm
+++ b/lib/System/Info.pm
@@ -72,7 +72,7 @@ sub new {
     $^O =~ m/haiku/              and return System::Info::Haiku->new;
     $^O =~ m/hp-?ux/i            and return System::Info::HPUX->new;
     $^O =~ m/irix/i              and return System::Info::Irix->new;
-    $^O =~ m/linux/i             and return System::Info::Linux->new;
+    $^O =~ m/linux|android/i     and return System::Info::Linux->new;
     $^O =~ m/solaris|sunos|osf/i and return System::Info::Solaris->new;
     $^O =~ m/VMS/                and return System::Info::VMS->new;
     $^O =~ m/mswin32|windows/i   and return System::Info::Windows->new;
@@ -109,11 +109,30 @@ C<sysinfo_hash> returns a hash reference with basic system information, like:
     osvers    => '4.13.10-1-default'
     }
 
+The cpu_cores count refers to logical cores. On MacOS there is a C<physical_cores>
+count in addition, it will be the same as C<cpu_cores> for Apple Silicon, but not
+for an Intel Mac with SMT enabled:
+
+  {
+    cpu_cores      => '8',
+    cpu            => 'Quad-Core Intel Core i7 (2 GHz)',
+    physical_cores => '4',
+    os             => 'darwin - 20.6.0 (Mac OS X - macOS 11.7.10 (20G1427))',
+    hostname       => '192.168.1.6',
+    distro         => 'Darwin 11.7.10',
+    cpu_count      => '1 [4 cores]',
+    osname         => 'Darwin',
+    cpu_type       => 'x86_64',
+    osvers         => '11.7.10'
+  }
+
 =cut
 
 sub sysinfo_hash {
-    my $si = System::Info->new;
+    my $si   = System::Info->new;
+    my %phys = $si->{_phys_core} ? (physical_cores => $si->{_phys_core}) : ();
     return {
+	%phys,
 	hostname  => $si->{_host},
 	cpu       => $si->{_cpu},
 	cpu_type  => $si->{_cpu_type},

--- a/lib/System/Info.pm
+++ b/lib/System/Info.pm
@@ -109,9 +109,9 @@ C<sysinfo_hash> returns a hash reference with basic system information, like:
     osvers    => '4.13.10-1-default'
     }
 
-The cpu_cores count refers to logical cores. On MacOS there is a C<physical_cores>
-count in addition, it will be the same as C<cpu_cores> for Apple Silicon, but not
-for an Intel Mac with SMT enabled:
+The C<cpu_cores> count refers to logical cores. On MacOS there is also a
+C<physical_cores> count, which will be the same as C<cpu_cores> for Apple Silicon,
+but not for an Intel Mac with SMT enabled:
 
   {
     cpu_cores      => '8',

--- a/lib/System/Info/Darwin.pm
+++ b/lib/System/Info/Darwin.pm
@@ -35,21 +35,27 @@ sub prepare_sysinfo {
 	$self->{__os} =~ s{\)$}{ - $kv)};
 	}
 
-    my $model = $system_profiler->{"machine name"} ||
-		$system_profiler->{"machine model"};
-
-    my $ncpu = # $scl->{"hw.ncpu"} ||
-	$system_profiler->{"number of cpus"};
+    # This is physical processors (sockets) which os not returned anywhere for Apple Silicon (implied 1)
+    my $ncpu = $system_profiler->{"number of cpus"} || 1;
     $system_profiler->{"total number of cores"} and
 	$ncpu .= " [$system_profiler->{'total number of cores'} cores]";
 
-    $self->{__cpu_type}  = $system_profiler->{"cpu type"}
-	if $system_profiler->{"cpu type"};
-    $self->{__cpu}       = # $scl->{"machdep.cpu.brand_string"} ||
-	"$model ($system_profiler->{'cpu speed'})";
+	# Confusingly, System::Info uses "cpu_type" for architecture and Apple uses
+	# "CPU Type" as the CPU model name. They are not the same thing.
+    $self->{__cpu}       = $system_profiler->{chip} ||
+	$system_profiler->{"cpu type"};
+    $self->{__cpu} .= " ($system_profiler->{'cpu speed'})"
+	if $system_profiler->{'cpu speed'};
+    $self->{__cpu_type}  = $system_profiler->{arch};
     $self->{__cpu_count} = $ncpu;
-    $scl->{"machdep.cpu.core_count"} and
-	$self->{_ncore}  = $scl->{"machdep.cpu.core_count"};
+    # _ncore reports hyperthreads for other platforms, so it would be
+    # hw.logicalcpu (or hw.logicalcpu_max which is the same unless the system
+    # has disabled cores).
+    # Alternative hw.ncpu is deprecated, keeping for ancient systems.
+    $self->{_ncore}      = $scl->{"hw.logicalcpu"} ||
+	$scl->{"hw.ncpu"};
+    $self->{_phys_core}  = $scl->{"hw.physicalcpu"} ||
+	$scl->{"hw.ncpu"};
 
     my $osv = do {
 	local $^W = 0;
@@ -94,11 +100,10 @@ sub __get_system_profiler {
 
     # convert newer output from Intel core duo
     my %keymap = (
-	"processor name"	=> "cpu type",
-	"processor speed"	=> "cpu speed",
-	"model name"		=> "machine name",
-	"model identifier"	=> "machine model",
-	"number of processors"  => "number of cpus",
+	"processor name"        => "cpu type",
+	"processor speed"       => "cpu speed",
+	"model name"            => "machine name",
+	"model identifier"      => "machine model",
 	"number of processors"  => "number of cpus",
 	"total number of cores" => "total number of cores",
 	);
@@ -109,12 +114,14 @@ sub __get_system_profiler {
 	}
 
     chomp ($system_profiler{"cpu type"} ||= `uname -m`);
-    $system_profiler{"cpu type"}  ||= "Unknown";
-    $system_profiler{"cpu type"}    =~ s/PowerPC\s*(\w+).*/macppc$1/;
     $system_profiler{"cpu speed"} ||= 0; # Mac M1 does not show CPU speed
     $system_profiler{"cpu speed"}   =~
 	s/(0(?:\.\d+)?)\s*GHz/sprintf "%d MHz", $1 * 1000/e;
-
+    $system_profiler{"cpu type"} ||= "Unknown";
+    $system_profiler{"cpu type"}   =~ s/\s*\([\d.]+\)//
+	if $system_profiler{"cpu speed"};
+    chomp ($system_profiler{arch} ||= `uname -m`);
+    $system_profiler{arch}        ||= "Unknown";
     return \%system_profiler;
     } # __get_system_profiler
 

--- a/t/sysinfo_macos.t
+++ b/t/sysinfo_macos.t
@@ -9,7 +9,7 @@ BEGIN { eval qq{use 5.009005}; $not595 = $@ }
 
 use Test::More $not595
     ? (skip_all => "This is only version $] (needs 5.9.5)")
-    : (tests    => 4);
+    : (tests    => 5);
 use Test::Warnings;
 
 use Carp qw( cluck );
@@ -18,9 +18,29 @@ our $DEBUG = 0;
 require System::Info::Darwin;
 
 my %output = (
-    mini_intel => {
-	uname  => "Mac mini (1.83 GHz) 1 [2 cores] Intel Core Duo",
+    m1_macbook_pro => {
+	uname   => "Apple M1 Pro 1 [10 (8 performance and 2 efficiency) cores] arm64",
+	uname_m => "arm64",
 	output => <<"__EOOUT__" },
+Hardware:
+
+    Hardware Overview:
+
+      Model Name: MacBook Pro
+      Model Identifier: MacBookPro18,1
+      Model Number: Z14W0013MB/A
+      Chip: Apple M1 Pro
+      Total Number of Cores: 10 (8 performance and 2 efficiency)
+      Memory: 32 GB
+      System Firmware Version: 8422.141.2
+      OS Loader Version: 8422.141.2
+      Activation Lock Status: Disabled
+__EOOUT__
+
+    mini_intel => {
+	uname   => "Intel Core Duo (1.83 GHz) 1 [2 cores] x86_64",
+	uname_m => "x86_64",
+	output  => <<"__EOOUT__" },
 Hardware:
     Hardware Overview:
       Model Name: Mac mini
@@ -37,7 +57,8 @@ Hardware:
 __EOOUT__
 
     ibook_g4 => {
-	uname  => "iBook G4 (1.07 GHz) 1 macppcG4",
+	uname  => "PowerPC G4 (1.07 GHz) 1 ppc",
+	uname_m => "ppc",
 	output => <<"__EOOUT__" },
 Hardware:
 
@@ -55,7 +76,8 @@ Hardware:
 __EOOUT__
 
     macbook_pro => {
-	uname  => "MacBook Pro (2.4 GHz) 1 [2 cores] Intel Core 2 Duo",
+	uname  => "Intel Core 2 Duo (2.4 GHz) 1 [2 cores] x86_64",
+	uname_m => "x86_64",
 	output => <<"__EOOUT__" },
 Hardware:
 
@@ -77,19 +99,22 @@ Hardware:
 __EOOUT__
     );
 
-our $OUTPUT;
+our $SYS_OUTPUT;
+our $UNAME_OUTPUT;
+
 sub fake_qx {
     $DEBUG and cluck ("<$_[0]>");
 
-    $_[0] =~ m{/usr/sbin/system_profiler}
-	? $OUTPUT
-	: CORE::readpipe ($_[0]);
+    $_[0] =~ m{/usr/sbin/system_profiler} ? $SYS_OUTPUT
+		: $_[0] =~ m{uname -m} ? $UNAME_OUTPUT
+		: CORE::readpipe ($_[0]);
     } # fake_qx
 
 BEGIN { *CORE::GLOBAL::readpipe = \&fake_qx }
 
 for my $model (keys %output) {
-    $OUTPUT = $output{$model}{output};
+    $SYS_OUTPUT = $output{$model}{output};
+    $UNAME_OUTPUT = $output{$model}{uname_m};
 
     local $^O = "Darwin";
     my $info = System::Info::Darwin->new;


### PR DESCRIPTION
Various fixes for MacOS to make it behave similar to the Linux platform:
- `cpu` will now return the actual CPU model name (e.g. Intel i7 / Apple M1 etc) and `cpu_type` will return the architecture (x86_64, arm64). I think the confusion started because of the `cpu_type` selected as the hash key to store architecture is very similar to the "CPU Type" Apple profiler entry which was the CPU model.
I don't think the actual computer model (MacBook Pro etc) should be returned in any "cpu" field. It would be fine for a "machine_model" field or something like that.
- `cpu_cores` now returns the logical core count in the recommended way (`hw.logicalcpu`), to match the Linux behaviour. I added a `physical_cores` field which returns the physical count that was reported previously as `cpu_cores`. Similar functionality can be added to Linux.
- POD clarifies behaviour and tests are added.

If some of the changes are not desired, I could take them out of this PR of course.